### PR TITLE
Corrected the XPath extracting the SAMLResponse

### DIFF
--- a/aws_adfs/roles_assertion_extractor.py
+++ b/aws_adfs/roles_assertion_extractor.py
@@ -18,7 +18,7 @@ def extract(html):
             exit(-1)
 
     # Retrieve Base64-encoded SAML assertion from form SAMLResponse input field
-    for element in html.findall('.//form[@name="hiddenform"]/input[@name="SAMLResponse"]'):
+    for element in html.findall('.//input[@name="SAMLResponse"]'):
         assertion = element.get('value')
 
     # If we did not get an error, but also do not have an assertion,


### PR DESCRIPTION
Trying to log in with the latest version of `aws-adfs` results in the below error:
```
aws-adfs login --adfs-host auth.mycorp.com

[authenticator authenticator.py:authenticate][...-MainProcess][...-MainThread] - ERROR: Cannot extract saml assertion. Re-authentication needed?
Username: MYDOMAIN\myusername
Password:
[authenticator authenticator.py:authenticate][...-MainProcess][...-MainThread] - ERROR: Cannot extract saml assertion. Re-authentication needed?
This account does not have access to any roles.
```

It seems like the root cause of this problem is a change in the structure of https://signin.aws.amazon.com/saml, and the fact that the SAML form is now called `saml_form` rather than `hiddenform`:
<img width="492" alt="screen shot 2018-09-19 at 10 39 04" src="https://user-images.githubusercontent.com/1089173/45745634-2d88f000-bbf9-11e8-8fe5-ce069ef50a39.png">

This PR relaxes the XPath expression responsible for extracting the `SAMLResponse` from the website to make it work with both versions of the form.